### PR TITLE
Prevent warnings from causing error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = function runSox(opts, callback) {
 			return flattened.concat(ele)
 		}, [])
 
-	var sox = spawn(opts.soxPath || 'sox', args, { stdio: [ 'pipe', 'pipe', 'inherit' ] })
+	var sox = spawn(opts.soxPath || 'sox', args, { stdio: [ 'pipe', 'pipe', process.stderr ] })
 	sox.on('error', cb)
 	sox.on('close', function (code, signal) {
 		if (code) {

--- a/index.js
+++ b/index.js
@@ -20,11 +20,8 @@ module.exports = function runSox(opts, callback) {
 			return flattened.concat(ele)
 		}, [])
 
-	var sox = spawn(opts.soxPath || 'sox', args)
+	var sox = spawn(opts.soxPath || 'sox', args, { stdio: [ 'pipe', 'pipe', 'inherit' ] })
 	sox.on('error', cb)
-	sox.stderr.on('data', function (stderr) {
-		cb(new Error(stderr))
-	})
 	sox.on('close', function (code, signal) {
 		if (code) {
 			cb(new Error(signal))


### PR DESCRIPTION
We don't want e.g. a 'clipping' warning to prevent the process completing.  But anything going to `stderr` is causing an error to be passed to the callback.

So, I've removed the `error` handler for `stderr` and instead am just logging it out to the parent process' `stderr`.  This also means you can see entirely the warning - as with the current schema, just the first chunk is emitted in the error message, which generally results in only the first line in the warning output.

If there was a 'real' error, this would still be handled in the `.on('close', () => {})`