### PR TITLE
Add option for null output for spectrogram generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ var sox = require('sox.js')
 	- `errOnStderr` **boolean** *optional* - SoX sometimes logs warnings to stderr. By default, sox.js will call the callback with an error. If you set this to `false`, then the errors will be passed along to `process.stderr`, and the callback will not be called with an error. Defaults to `true`.
 	- `global` **object** *optional* - Global SoX options
 	- `inputFile` **string** *required* - The file path of the input file
-	- `outputFile` **string** *required* - The file path of the output file
+	- `outputFile` **string** *optional* - The file path of the output file, null output (`-n`) will be used if not present
 	- `input` **object** *optional* - These options will be used to interpret the incoming stream.
 	- `output` **object** *optional* - These options will be used to format the outgoing stream. When an output option isn't supplied, the output file will have the same format as the input file where possible.
 	- `effects` **string|array of strings/numbers** *optional*
@@ -71,7 +71,7 @@ var sox = require('sox.js')
 
 ### `options` object
 
-An object of options. Every option is optional except `options.inputFile` and `options.outputFile`.
+An object of options. Every option is optional except `options.inputFile`.
 
 If you want an exhaustive list of each option in depth, take a look at the [SoX documentation](http://sox.sourceforge.net/sox.html#OPTIONS).
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ var onetime = require('onetime')
 module.exports = function runSox(opts, callback) {
 	if (!opts || typeof opts !== 'object') throw new Error('options must be an object')
 	if (!opts.inputFile) throw new Error('options.inputFile is a required parameter')
-	if (!opts.outputFile) throw new Error('options.outputFile is a required parameter')
 
 	var cb = onetime(callback || function (e) { if (e) throw e })
 
@@ -14,7 +13,7 @@ module.exports = function runSox(opts, callback) {
 		.concat(hashToArray(opts.input || []))
 		.concat(opts.inputFile)
 		.concat(hashToArray(opts.output || []))
-		.concat(opts.outputFile)
+		.concat(opts.outputFile || ['-n'])
 		.concat(opts.effects || [])
 		.reduce(function (flattened, ele) {
 			return flattened.concat(ele)


### PR DESCRIPTION
Thanks for this module!

I needed this for both trimming a file but also spectrogram generation. Sox's spectrogram generation requires a null output file, the `-n` option, which wasn't possible with `outputFile` being a required item.

My solution was to fall back to `-n` if `outputFile` is not provided.

Feedback welcomed.